### PR TITLE
user_data should be userdata

### DIFF
--- a/plugins/modules/vultr_server.py
+++ b/plugins/modules/vultr_server.py
@@ -540,7 +540,7 @@ class AnsibleVultrServer(Vultr):
                 'notify_activate': self.get_yes_or_no('notify_activate'),
                 'tag': self.module.params.get('tag'),
                 'reserved_ip_v4': self.module.params.get('reserved_ip_v4'),
-                'user_data': self.get_user_data(),
+                'userdata': self.get_user_data(),
                 'SCRIPTID': self.get_startup_script().get('SCRIPTID'),
             }
             self.api_query(


### PR DESCRIPTION
According to the v1 API for /v1/server/create, the user-data item should be sent as 'userdata', not 'user_data'. Adds the user-data to the instance properly at instance creation.