### PR TITLE
Support float for "allowed_bandwidth_gb" parameter in server info APIs response.

### DIFF
--- a/plugins/inventory/vultr.py
+++ b/plugins/inventory/vultr.py
@@ -85,7 +85,7 @@ SCHEMA = {
     'SUBID': dict(key='id'),
     'label': dict(key='name'),
     'date_created': dict(),
-    'allowed_bandwidth_gb': dict(convert_to='int'),
+    'allowed_bandwidth_gb': dict(convert_to='float'),
     'auto_backups': dict(key='auto_backup_enabled', convert_to='bool'),
     'current_bandwidth_gb': dict(),
     'kvm_url': dict(),

--- a/plugins/modules/vultr_server.py
+++ b/plugins/modules/vultr_server.py
@@ -210,8 +210,8 @@ vultr_server:
     allowed_bandwidth_gb:
       description: Allowed bandwidth to use in GB
       returned: success
-      type: int
-      sample: 1000
+      type: float
+      sample: 1000.5
     auto_backup_enabled:
       description: Whether automatic backups are enabled
       returned: success
@@ -359,7 +359,7 @@ class AnsibleVultrServer(Vultr):
             'SUBID': dict(key='id'),
             'label': dict(key='name'),
             'date_created': dict(),
-            'allowed_bandwidth_gb': dict(convert_to='int'),
+            'allowed_bandwidth_gb': dict(convert_to='float'),
             'auto_backups': dict(key='auto_backup_enabled', convert_to='bool'),
             'current_bandwidth_gb': dict(),
             'kvm_url': dict(),

--- a/plugins/modules/vultr_server_baremetal.py
+++ b/plugins/modules/vultr_server_baremetal.py
@@ -152,8 +152,8 @@ vultr_server_baremetal:
     allowed_bandwidth_gb:
       description: Allowed bandwidth to use in GB
       returned: success
-      type: int
-      sample: 1000
+      type: float
+      sample: 1000.5
     cost_per_month:
       description: Cost per month for the server
       returned: success
@@ -271,7 +271,7 @@ class AnsibleVultrServerBareMetal(Vultr):
             'SUBID': dict(key='id'),
             'label': dict(key='name'),
             'date_created': dict(),
-            'allowed_bandwidth_gb': dict(convert_to='int'),
+            'allowed_bandwidth_gb': dict(convert_to='float'),
             'current_bandwidth_gb': dict(),
             'default_password': dict(),
             'internal_ip': dict(),

--- a/plugins/modules/vultr_server_info.py
+++ b/plugins/modules/vultr_server_info.py
@@ -86,8 +86,8 @@ vultr_server_info:
     allowed_bandwidth_gb:
       description: Allowed bandwidth to use in GB
       returned: success
-      type: int
-      sample: 1000
+      type: float
+      sample: 1000.5
     auto_backup_enabled:
       description: Whether automatic backups are enabled
       returned: success
@@ -232,7 +232,7 @@ class AnsibleVultrServerInfo(Vultr):
             "FIREWALLGROUPID": dict(key='firewallgroup', transform=self._get_firewallgroup_name),
             "SUBID": dict(key='id', convert_to='int'),
             "VPSPLANID": dict(key='plan', convert_to='int', transform=self._get_plan_name),
-            "allowed_bandwidth_gb": dict(convert_to='int'),
+            "allowed_bandwidth_gb": dict(convert_to='float'),
             'auto_backups': dict(key='auto_backup_enabled', convert_to='bool'),
             "cost_per_month": dict(convert_to='float'),
             "current_bandwidth_gb": dict(convert_to='float'),


### PR DESCRIPTION
Got this issue https://github.com/trailofbits/algo/issues/14569 during deploying to vultr. Vultr API returns float values for "allowed_bandwidth_gb" parameter, which is not documented, but currently is actual.

Example of https://api.vultr.com/v1/server/list response:

"allowed_bandwidth_gb":"341.333"